### PR TITLE
Feature: Allow passing single model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: forecast.vocs
 Title: Forecast Case Notifications using Variant of Concern Strain
     Dynamics
-Version: 0.0.3.3000
+Version: 0.0.3.4000
 Authors@R:
     person("Sam Abbott", , , "sam.abbott@lshtm.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8057-8037"))

--- a/R/forecast.R
+++ b/R/forecast.R
@@ -1,7 +1,8 @@
 #' Forecast using branching processes at a target date
 #'
-#' @param models A list of models to use named by strain. If not supplied
-#' uses the package default model for that strain.
+#' @param models A model as supplied by `load_model()`. If not supplied the
+#' default for that strain is used. If multiple strain models are being forecast
+#' then `models` should be a list models.
 #'
 #' @param forecast_date Date at which to forecast. Defaults to the
 #' maximum date in `obs`.
@@ -64,6 +65,9 @@ forecast <- function(obs,
                      id = 0,
                      ...) {
   if (!is.null(models)) {
+    if (length(models) == 1 & length(strains) == 1) {
+      models <- list(models)
+    }
     stopifnot(
       "Number of models supplied must be equal to the numer of strain
        forecasts specified." = length(models) == length(strains)

--- a/man/forecast.Rd
+++ b/man/forecast.Rd
@@ -62,8 +62,9 @@ determined from the data), "scaled" (a fixed scaling between strains), and
 \item{overdispersion}{Logical, defaults to \code{TRUE}. Should the observations
 used include overdispersion.}
 
-\item{models}{A list of models to use named by strain. If not supplied
-uses the package default model for that strain.}
+\item{models}{A model as supplied by \code{load_model()}. If not supplied the
+default for that strain is used. If multiple strain models are being forecast
+then \code{models} should be a list models.}
 
 \item{likelihood}{Logical, defaults to \code{TRUE}. Should the likelihood be
 included in the model.extract}


### PR DESCRIPTION
This PR allows a single model to be passed without being wrapped in a list to `forecast`. This is a qaulity of life feature but does make the documentaiton slightly more confusing. 